### PR TITLE
fix: models index correction with v7 upgrade

### DIFF
--- a/how-tos/maintain/upgrade-notes-sql-mongodb/upgrade-to-v7.md
+++ b/how-tos/maintain/upgrade-notes-sql-mongodb/upgrade-to-v7.md
@@ -118,7 +118,7 @@ databasesConfiguration.forEach((databaseInfo) => {
     .filter((file) => file.indexOf('.') !== 0 && file !== 'index.js')
     .forEach((file) => {
       try {
-        const model = connection.import(path.join(modelsDir, file));
+        const model = connection.import(path.join(modelsDir, file))(connection, Sequelize.DataTypes);
         db[model.name] = model;
       } catch (error) {
         console.error('Model creation error: ' + error);


### PR DESCRIPTION
While upgrading forest-express-sequelize from 6.1.4 to 7.12.5 (or more recent) I encountered the problem that the generated .forestadmin-schema.json only contained the "meta" root key but not "collections".
This adaption found in the forest-live-demo-e-commerce made it work again

FTR: I also needed to change `connection.import` to `connection.import` to `require` but I consider it not relevant for the upgrade guide.